### PR TITLE
Remove broken and questionable OpenCL code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Get informations from AMD Radeon GPUs.
 
 ### Dependencies
 
-* ocl-icd
-* opencl-headers
+* libpci
 
 ### Build
 
@@ -30,7 +29,6 @@ Get informations from AMD Radeon GPUs.
 
 Options:
 * `-h` `--help` Display Help
-* `-o` `--opencl` Order by OpenCL ID
 * `-q` `--quiet` Only output results
 * `-s` `--short` Short form output - 1 GPU/line - `<OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<Memory Type>`
 * `--use-stderr` Output errors to stderr

--- a/amdgpuinfo.c
+++ b/amdgpuinfo.c
@@ -21,6 +21,8 @@
 #include <regex.h>
 #include <strings.h>
 
+#include "config.h"
+
 #ifdef __APPLE_CC__
 #include <OpenCL/opencl.h>
 #include <OpenCL/cl_ext.h>
@@ -31,8 +33,6 @@
 #ifdef CL_DEVICE_TOPOLOGY_AMD
   #define USE_OPENCL 1
 #endif
-
-#define VERSION "AMDGPUInfo v0.1"
 
 #define LOG_INFO 1
 #define LOG_ERROR 2
@@ -166,7 +166,8 @@ static void print(int priority, const char *fmt, ...)
 // show help
 static void showhelp(char *program)
 {
-  printf("%s\n\n"
+  printf(
+    NAME " v"  VERSION "\n\n"
     "Usage: %s [options]\n\n"
     "Options:\n"
     "-b, --biosonly  Only output BIOS Versions (implies -s with <OpenCLID>:<BIOSVersion> output)\n"
@@ -179,7 +180,7 @@ static void showhelp(char *program)
     "-q, --quiet     Only output results\n"
     "-s, --short     Short form output - 1 GPU/line - <OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<BIOSVersion>:<Memory Type>\n"
     "--use-stderr    Output errors to stderr\n"
-    "\n", VERSION, program);
+    "\n", program);
 }
 
 
@@ -837,7 +838,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  print(LOG_INFO, "%s\n", VERSION);
+  print(LOG_INFO, NAME " v" VERSION "\n");
 
   pci = pci_alloc();
   pci_init(pci);

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('amdgpuinfo', 'c',
+project('AMDGPUInfo', 'c',
         version: '0.1',
         meson_version: '>= 0.45.1',
         default_options : [
@@ -12,7 +12,16 @@ project_args = [
 ]
 add_project_arguments(project_args, language: ['c'])
 
+conf = configuration_data()
+conf.set_quoted('VERSION', meson.project_version())
+conf.set_quoted('NAME', meson.project_name())
+
 pci_dep = dependency('libpci')
+
+configure_file(
+  output: 'config.h',
+  configuration: conf,
+)
 
 executable(
   'amdgpuinfo', ['amdgpuinfo.c'],


### PR DESCRIPTION
I actuallt have fixed this code, which uses an unmaintained AMD hardware
specific extension. The code was pretty badly written, if you want to
see my improvements on it check out my `opencl` branch.

After getting the code to work I noticed it's sole purpose was
to use the `cl_amd_device_attribute_query` extension to assign a OpenCL
device ID to the card detected by amdgpuinfo over the PCIe identifier.

This is tottaly unuseful, since just worked with AMD's OpenCL
implementation and `clinfo` provides way more OpenCL specific information.

`clinfo` also works with Mesa. Since this is `amdgpuinfo` we don't need
that here.

My branch was using `hwloc`, since it was providing the structs and constants
required to make the extension work in the first place. Khonos does not ship it
in it's headers. Apparently it also requires CL 1.2 and Mesa only implements
1.1.

More info about the extension can be found here:
https://github.com/KhronosGroup/OpenCL-Registry/blob/master/extensions/amd/cl_amd_device_attribute_query.txt