### PR TITLE
Remove redundant options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,3 @@ Get informations from AMD Radeon GPUs.
 Options:
 * `-h` `--help` Display Help
 * `-s` `--short` Short form output - 1 GPU/line - `<OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<Memory Type>`
-* `--use-stderr` Output errors to stderr
-

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Get informations from AMD Radeon GPUs.
 
 Options:
 * `-h` `--help` Display Help
-* `-q` `--quiet` Only output results
 * `-s` `--short` Short form output - 1 GPU/line - `<OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<Memory Type>`
 * `--use-stderr` Output errors to stderr
 

--- a/amdgpuinfo.c
+++ b/amdgpuinfo.c
@@ -126,7 +126,6 @@ static const char *amd_asic_name[] = {
  ***********************************/
 bool opt_bios_only = false; // --biosonly / -b
 bool opt_output_short = false; // --short / -s
-bool opt_use_stderr = false;  // --use-stderr
 bool opt_show_memconfig = false; // --memconfig / -c
 
 // output function that only displays if verbose is on
@@ -135,7 +134,7 @@ static void print(int priority, const char *fmt, ...)
   va_list args;
 
   va_start(args, fmt);
-  if (priority == LOG_ERROR && opt_use_stderr) {
+  if (priority == LOG_ERROR) {
     vfprintf(stderr, fmt, args);
   } else {
     vprintf(fmt, args);
@@ -154,7 +153,6 @@ static void showhelp(char *program)
     "-c, --memconfig Output the memory configuration\n"
     "-h, --help      Help\n"
     "-s, --short     Short form output - 1 GPU/line - <OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<BIOSVersion>:<Memory Type>\n"
-    "--use-stderr    Output errors to stderr\n"
     "\n", program);
 }
 
@@ -176,8 +174,6 @@ static bool load_options(int argc, char *argv[])
       opt_output_short = true;
     } else if (!strcasecmp("--memconfig", argv[i]) || !strcasecmp("-c", argv[i])) {
       opt_show_memconfig = true;
-    } else if (!strcasecmp("--use-stderr", argv[i])) {
-      opt_use_stderr = true;
     }
   }
 

--- a/amdgpuinfo.c
+++ b/amdgpuinfo.c
@@ -125,7 +125,6 @@ static const char *amd_asic_name[] = {
  * Program Options
  ***********************************/
 bool opt_bios_only = false; // --biosonly / -b
-bool opt_opencl_order = false; // --opencl / -o
 bool opt_output_short = false; // --short / -s
 bool opt_quiet = false;  // --quiet / -q to turn off
 bool opt_use_stderr = false;  // --use-stderr
@@ -159,7 +158,6 @@ static void showhelp(char *program)
     "-b, --biosonly  Only output BIOS Versions (implies -s with <OpenCLID>:<BIOSVersion> output)\n"
     "-c, --memconfig Output the memory configuration\n"
     "-h, --help      Help\n"
-    "-n, --no-opencl Disable OpenCL information lookup\n"
     "-q, --quiet     Only output results\n"
     "-s, --short     Short form output - 1 GPU/line - <OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<BIOSVersion>:<Memory Type>\n"
     "--use-stderr    Output errors to stderr\n"
@@ -177,8 +175,6 @@ static bool load_options(int argc, char *argv[])
     if (!strcasecmp("--help", argv[i]) || !strcasecmp("-h", argv[i])) {
       showhelp(argv[0]);
       return false;
-    } else if (!strcasecmp("--opencl", argv[i]) || !strcasecmp("-o", argv[i])) {
-      opt_opencl_order = true;
     } else if (!strcasecmp("--biosonly", argv[i]) || !strcasecmp("-b", argv[i])) {
       opt_bios_only = true;
       opt_output_short = true;

--- a/amdgpuinfo.c
+++ b/amdgpuinfo.c
@@ -126,17 +126,12 @@ static const char *amd_asic_name[] = {
  ***********************************/
 bool opt_bios_only = false; // --biosonly / -b
 bool opt_output_short = false; // --short / -s
-bool opt_quiet = false;  // --quiet / -q to turn off
 bool opt_use_stderr = false;  // --use-stderr
 bool opt_show_memconfig = false; // --memconfig / -c
 
 // output function that only displays if verbose is on
 static void print(int priority, const char *fmt, ...)
 {
-  if (opt_quiet && !(priority == LOG_ERROR && opt_use_stderr)) {
-    return;
-  }
-
   va_list args;
 
   va_start(args, fmt);
@@ -158,7 +153,6 @@ static void showhelp(char *program)
     "-b, --biosonly  Only output BIOS Versions (implies -s with <OpenCLID>:<BIOSVersion> output)\n"
     "-c, --memconfig Output the memory configuration\n"
     "-h, --help      Help\n"
-    "-q, --quiet     Only output results\n"
     "-s, --short     Short form output - 1 GPU/line - <OpenCLID>:<PCI Bus.Dev.Func>:<GPU Type>:<BIOSVersion>:<Memory Type>\n"
     "--use-stderr    Output errors to stderr\n"
     "\n", program);
@@ -180,8 +174,6 @@ static bool load_options(int argc, char *argv[])
       opt_output_short = true;
     } else if (!strcasecmp("--short", argv[i]) || !strcasecmp("-s", argv[i])) {
       opt_output_short = true;
-    } else if (!strcasecmp("--quiet", argv[i]) || !strcasecmp("-q", argv[i])) {
-      opt_quiet = true;
     } else if (!strcasecmp("--memconfig", argv[i]) || !strcasecmp("-c", argv[i])) {
       opt_show_memconfig = true;
     } else if (!strcasecmp("--use-stderr", argv[i])) {


### PR DESCRIPTION
* Remove some OpenCL option remains
* Quiet was only silencing one line. Also it's not useful for a tool that just outputs information.
* Why should the errors not be printed to stderr?